### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Location URLs

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Zod URL Validation Vulnerability
+**Vulnerability:** Zod's `z.string().url()` validation accepts `javascript:` protocol URLs, which can lead to Stored Cross-Site Scripting (XSS) if the URL is rendered in an `href` or `src` attribute.
+**Learning:** Standard library validators often strictly follow specs (like WHATWG URL) which may be too permissive for security contexts. "Valid URL" != "Safe URL".
+**Prevention:** Always use `.refine()` to explicitly allow only `http:` and `https:` protocols when validating user-provided URLs.

--- a/src/components/admin/locations/LocationFormDialog.tsx
+++ b/src/components/admin/locations/LocationFormDialog.tsx
@@ -18,8 +18,20 @@ const locationSchema = z.object({
   name: z.string().min(1, 'Navn må fylles ut'),
   address: z.string().min(1, 'Adresse må fylles ut'),
   description: z.string().optional(),
-  imageUrl: z.string().url('Ugyldig URL').optional().or(z.literal('')),
-  googleEarthLink: z.string().url('Ugyldig URL').optional().or(z.literal('')),
+  imageUrl: z.string().url('Ugyldig URL').refine((val) => {
+    try {
+      return ['http:', 'https:'].includes(new URL(val).protocol);
+    } catch {
+      return false;
+    }
+  }, 'URL må starte med http:// eller https://').optional().or(z.literal('')),
+  googleEarthLink: z.string().url('Ugyldig URL').refine((val) => {
+    try {
+      return ['http:', 'https:'].includes(new URL(val).protocol);
+    } catch {
+      return false;
+    }
+  }, 'URL må starte med http:// eller https://').optional().or(z.literal('')),
   recommendedEquipment: z.string().optional(),
   maintenanceFrequency: z.coerce.number().min(1, 'Frekvens må være større enn 0'),
   edgeCuttingFrequency: z.coerce.number().min(1, 'Frekvens må være større enn 0'),


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

**Severity:** HIGH

**Vulnerability:**
Zod's standard `z.string().url()` validation is compliant with specifications that allow the `javascript:` protocol. This allows an attacker (or compromised admin) to inject malicious JavaScript into `href` or `src` attributes (Stored XSS).

**Fix:**
Implemented a strict protocol check using Zod's `.refine()` method on `imageUrl` and `googleEarthLink` fields in the `LocationFormDialog` component. The validation now explicitly requires URLs to start with `http:` or `https:`.

**Verification:**
Verified using a reproduction script that `javascript:alert(1)` is now rejected while `https://example.com` is accepted.
Ran full test suite (`npx vitest run`) to ensure no regressions.

---
*PR created automatically by Jules for task [14839474767507380137](https://jules.google.com/task/14839474767507380137) started by @Mxlaugh91*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation for location form fields to enforce HTTP and HTTPS protocols only, preventing acceptance of unsafe URL schemes and improving security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->