### PR TITLE
🛡️ Sentinel: Fix unrestricted time entry updates

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-09 - Unrestricted Time Entry Updates
+**Vulnerability:** Tagged users could update any field in a time entry document (e.g., `hours`, `employeeId`, `locationId`), leading to potential data tampering or attribution fraud.
+**Learning:** Firestore `allow update` rules that rely on `hasAny(['field'])` without `affectedKeys().hasOnly(...)` restrictions are dangerous because they open the entire document to modification once the condition is met.
+**Prevention:** Always combine role/condition-based access with `request.resource.data.diff(resource.data).affectedKeys().hasOnly(['allowedFields'])` to strictly limit the scope of changes.

--- a/firestore.rules
+++ b/firestore.rules
@@ -103,10 +103,12 @@ service cloud.firestore {
       // Kun administratorer kan oppdatere eller slette tidsregistreringer
       allow update, delete: if isAdmin();
 
-      // Brukere kan oppdatere tidsregistreringer de er tagget i (f.eks. for å markere som fullført)
+      // Brukere kan oppdatere tidsregistreringer de er tagget i
+      // Vi begrenser oppdateringer til kun å gjelde taggedEmployeeIds (f.eks. legge til/fjerne tagger)
       allow update: if isAuthenticated() &&
         resource.data.keys().hasAny(['taggedEmployeeIds']) &&
-        request.auth.uid in resource.data.taggedEmployeeIds;
+        request.auth.uid in resource.data.taggedEmployeeIds &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['taggedEmployeeIds']);
     }
 
     // --- Samling: mowers ---


### PR DESCRIPTION
This PR addresses a high-severity security vulnerability in `firestore.rules`.

Previously, users tagged in a time entry were allowed to update the entire document, which meant they could potentially change critical fields such as `hours`, `employeeId`, or `locationId`.

This PR restricts the update permission for tagged users to *only* allow modifications to the `taggedEmployeeIds` field (and implicitly `updatedAt` via logic, though restricted in rules).

Also added `.Jules/sentinel.md` to document this critical learning.

---
*PR created automatically by Jules for task [18427218445221464081](https://jules.google.com/task/18427218445221464081) started by @Mxlaugh91*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted time entry update permissions to prevent unauthorized modifications. Tagged users can now only modify tagging assignments, protecting critical data fields from tampering and unauthorized changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->