### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure update rule in firestore.rules

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Unused Permissive Firestore Rule
+**Vulnerability:** A Firestore rule allowed users tagged in a time entry to update the entire document, including sensitive fields like hours and employee ID.
+**Learning:** Feature ideas (like "marking as complete") left in rules but implemented differently in code can leave dormant high-severity vulnerabilities.
+**Prevention:** Verify that every permissive rule in `firestore.rules` has a corresponding and necessary usage in the application code. Remove unused rules immediately.

--- a/firestore.rules
+++ b/firestore.rules
@@ -102,11 +102,6 @@ service cloud.firestore {
 
       // Kun administratorer kan oppdatere eller slette tidsregistreringer
       allow update, delete: if isAdmin();
-
-      // Brukere kan oppdatere tidsregistreringer de er tagget i (f.eks. for å markere som fullført)
-      allow update: if isAuthenticated() &&
-        resource.data.keys().hasAny(['taggedEmployeeIds']) &&
-        request.auth.uid in resource.data.taggedEmployeeIds;
     }
 
     // --- Samling: mowers ---


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A Firestore rule allowed users tagged in a time entry (via `taggedEmployeeIds`) to update the entire document. This could allow a tagged user to modify sensitive fields like `hours`, `employeeId`, or `locationId`.
🎯 Impact: Data integrity compromise. A user could impersonate another employee or falsify hours for a job they were merely tagged in.
🔧 Fix: Removed the permissive `allow update` rule from the `timeEntries` collection.
✅ Verification: Verified via code analysis that this rule was unused (tagged users create separate time entries) and ran `npx vitest run` to ensure no regressions.

---
*PR created automatically by Jules for task [15325340333815370257](https://jules.google.com/task/15325340333815370257) started by @Mxlaugh91*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted timeEntries modifications to admin-only access, removing previously allowed updates by non-admin authenticated users.

* **Documentation**
  * Added security documentation describing a dormant Firestore rule vulnerability, associated learnings, and prevention best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->