### PR TITLE
🛡️ Sentinel: Fix critical Firestore permission creep vulnerabilities

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-05 - Permission Creep in Firestore Rules
+**Vulnerability:** Found `allow update` rules in `firestore.rules` that granted full document update permissions to authenticated users for `timeEntries` and `serviceIntervals`.
+**Learning:** Using `isAuthenticated()` alone for update operations allows users to modify *any* field in the document (including critical ones like `hours` or `hourInterval`), not just the intended fields.
+**Prevention:** Always restrict update operations using `request.resource.data.diff(resource.data).affectedKeys().hasOnly([...])` to limit the scope of changes, even for trusted roles like employees.

--- a/firestore.rules
+++ b/firestore.rules
@@ -104,9 +104,11 @@ service cloud.firestore {
       allow update, delete: if isAdmin();
 
       // Brukere kan oppdatere tidsregistreringer de er tagget i (f.eks. for å markere som fullført)
+      // Begrenset til kun å oppdatere 'taggedEmployeeIds' feltet
       allow update: if isAuthenticated() &&
         resource.data.keys().hasAny(['taggedEmployeeIds']) &&
-        request.auth.uid in resource.data.taggedEmployeeIds;
+        request.auth.uid in resource.data.taggedEmployeeIds &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['taggedEmployeeIds']);
     }
 
     // --- Samling: mowers ---
@@ -142,7 +144,13 @@ service cloud.firestore {
       allow create, delete: if isAdmin();
 
       // Alle autentiserte brukere kan oppdatere serviceintervaller (f.eks. for å tilbakestille intervaller)
-      allow update: if isAuthenticated();
+      // Men de kan kun oppdatere feltene relatert til tilbakestilling
+      allow update: if isAdmin() ||
+        (isAuthenticated() &&
+         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['lastResetHours', 'lastResetDate', 'lastResetBy']) &&
+         request.resource.data.lastResetHours is number &&
+         request.resource.data.lastResetDate is timestamp &&
+         request.resource.data.lastResetBy is string);
 
       // Validering ved opprettelse av serviceintervall data
       allow create: if isAdmin() &&


### PR DESCRIPTION
**Vulnerability Fixes:**
1.  **Time Entries:** Previously, users tagged in a time entry could update *any* field in the document. This has been restricted so they can only modify `taggedEmployeeIds` (e.g., to untag themselves).
2.  **Service Intervals:** Previously, any authenticated user could update *any* field of a service interval. This has been restricted so non-admin users can only update `lastResetHours`, `lastResetDate`, and `lastResetBy`.

**Verification:**
- Verified `firestore.rules` syntax and logic manually (no local emulator available).
- Ran project tests (`pnpm test`) to ensure no regressions.


---
*PR created automatically by Jules for task [7918288316156559508](https://jules.google.com/task/7918288316156559508) started by @Mxlaugh91*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database security by restricting update permissions, preventing unauthorized modifications of unintended fields.
  * Implemented field-level validation to ensure only specific fields can be modified by authenticated users.

* **Documentation**
  * Added security documentation detailing permission vulnerabilities and recommended mitigation strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->