### PR TITLE
🛡️ Sentinel: Fix insecure serviceIntervals update rule

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-07 - Insecure Firestore Update Rules
+**Vulnerability:** The `serviceIntervals` collection allowed any authenticated user to update *any* field, including critical maintenance configuration like `description` and `hourInterval`.
+**Learning:** `allow update: if isAuthenticated();` is a dangerous default for shared collections. Even if the UI only exposes certain fields, the database rule must enforce field-level restrictions using `request.resource.data.diff(resource.data).affectedKeys()`.
+**Prevention:** Always use `affectedKeys().hasOnly([...])` when granting partial update access to non-admin users.

--- a/firestore.rules
+++ b/firestore.rules
@@ -141,8 +141,14 @@ service cloud.firestore {
       // Kun administratorer kan opprette eller slette serviceintervaller
       allow create, delete: if isAdmin();
 
-      // Alle autentiserte brukere kan oppdatere serviceintervaller (f.eks. for å tilbakestille intervaller)
-      allow update: if isAuthenticated();
+      // Kun administratorer kan oppdatere serviceintervaller generelt
+      allow update: if isAdmin();
+
+      // Ansatte kan kun oppdatere felter relatert til utført service
+      allow update: if isAuthenticated() &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['lastResetHours', 'lastResetDate', 'lastResetBy']) &&
+        request.resource.data.lastResetHours is number &&
+        request.resource.data.lastResetHours >= resource.data.lastResetHours;
 
       // Validering ved opprettelse av serviceintervall data
       allow create: if isAdmin() &&


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `serviceIntervals` collection allowed any authenticated user to update *any* field, including critical maintenance configuration like `description` and `hourInterval`.
🎯 Impact: A malicious or negligent employee could disable maintenance reminders or vandalism the descriptions, leading to equipment damage.
🔧 Fix: Replaced the permissive `allow update: if isAuthenticated();` with a stricter rule. Admins retain full access. Employees are now restricted to updating only `lastResetHours`, `lastResetDate`, and `lastResetBy`, and `lastResetHours` must be a valid number.
✅ Verification:
- Verified `firestore.rules` syntax manually.
- Verified that `resetServiceInterval` function in `equipmentService.ts` only sends the allowed fields, ensuring functionality is preserved.
- Ran `pnpm build` and `npx vitest run` to ensure project integrity.

---
*PR created automatically by Jules for task [14181332113963956644](https://jules.google.com/task/14181332113963956644) started by @Mxlaugh91*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security guidance for field-level access control in shared collections

* **Security & Access Control**
  * Restricted general service interval updates to administrators only
  * Implemented field-level validation for employee service record updates with type and value constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->